### PR TITLE
Specify 'utf8' encoding for text file read

### DIFF
--- a/shlep/main.py
+++ b/shlep/main.py
@@ -69,7 +69,7 @@ def shlep(
     for path in base.rglob("*"):
         if path.is_file() and not _is_excluded(base, path, spec, only_patterns):
             try:
-                content = path.read_text()
+                content = path.read_text(encoding="utf8")
             except UnicodeDecodeError:
                 logger.error(f"Could not read {path}")
             else:


### PR DESCRIPTION
I usually get encoding errors for the simplest of things. “ instead of " triggers an error. Having emojis in code triggers read_text() errors. Even though all files are UTF-8 encoded.

IMO, using `Path.read_text(encoding="utf8")` is better than not specifying the encoding because it enhances clarity, avoids guesswork, reduces the chance of encoding errors, etc...